### PR TITLE
Use `key` argument for `toJSON`

### DIFF
--- a/lib/cycle.js
+++ b/lib/cycle.js
@@ -39,7 +39,7 @@ exports.decycle = function decycle(object, options, replacer) {
     }
 
     if (value && typeof value.toJSON === 'function') {
-      value = value.toJSON();
+      value = value.toJSON(key);
     }
 
     if (typeof value === 'object' && value !== null &&

--- a/test/unit.js
+++ b/test/unit.js
@@ -14,8 +14,8 @@ describe('jsan', function() {
     });
 
     it('uses the toJSON() method when possible', function() {
-      var obj = { toJSON: function() { return 'foobar' } };
-      assert.equal(jsan.stringify(obj), '"foobar"');
+      var obj = { a: { b: 1, toJSON: function(key) { return key } } };
+      assert.equal(jsan.stringify(obj, null, null, false), '{"a":"a"}');
     });
 
     it('can handle dates', function() {


### PR DESCRIPTION
As discussed in https://github.com/zalmoxisus/redux-devtools-extension/issues/227, we should take `key` argument into account according to http://www.ecma-international.org/ecma-262/6.0/#sec-serializejsonproperty.