### PR TITLE
Support ES2015 Symbols

### DIFF
--- a/lib/cycle.js
+++ b/lib/cycle.js
@@ -37,6 +37,9 @@ exports.decycle = function decycle(object, options, replacer) {
     if (options['error'] && value instanceof Error) {
       return {$jsan: 'e' + value.message}
     }
+    if (options['error'] && typeof value === 'symbol') {
+      return {$jsan: 's' + String(value)}
+    }
 
     if (value && typeof value.toJSON === 'function') {
       value = value.toJSON();

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -42,6 +42,8 @@ exports.restore = function restore(obj, root) {
       var error = new Error(rest);
       error.stack = 'Stack is unavailable for jsan parsed errors';
       return error;
+    case 's':
+      return Symbol(rest.match(/Symbol\((.+)\)/)[1]);
     default:
       console.warn('unknown type', obj);
       return obj;

--- a/test/unit.js
+++ b/test/unit.js
@@ -58,6 +58,14 @@ describe('jsan', function() {
       assert.deepEqual(str, '{"e":{"$jsan":"e:("}}');
     });
 
+    it('can handle ES symbols', function() {
+      var obj = {
+        e: Symbol('a')
+      }
+      var str = jsan.stringify(obj, null, null, true);
+      assert.deepEqual(str, '{"e":{"$jsan":"sSymbol(a)"}}');
+    });
+
     it('works on objects with circular references', function() {
       var obj = {};
       obj['self'] = obj;


### PR DESCRIPTION
Symbols are widely used for example for Redux action types, so it's worth supporting them.