### PR TITLE
Prevent accessing property of undefined while retrocycling

### DIFF
--- a/lib/path-getter.js
+++ b/lib/path-getter.js
@@ -5,6 +5,7 @@ function pathGetter(obj, path) {
     var paths = getPaths(path);
     for (var i = 0; i < paths.length; i++) {
       path = paths[i].toString().replace(/\\"/g, '"');
+      if (typeof obj[path] === 'undefined' && i !== paths.length - 1) continue;
       obj = obj[path];
     }
   }


### PR DESCRIPTION
@kolodny, not sure you'll want to accept it, but I didn't want to use a fork only for this change.

For Redux DevTools we've implemented a hack to [support ImmutableJS](https://github.com/zalmoxisus/redux-devtools-extension/releases/tag/v2.12.1). The idea is pretty simple, we mark custom data in the [stringify replacer](https://github.com/zalmoxisus/remotedev-serialize/blob/master/immutable/serialize.js#L8-L20), then convert it back in the [parse reviver](https://github.com/zalmoxisus/remotedev-serialize/blob/master/immutable/serialize.js#L22-L39). The problem, however, is that the reviver alters the path for references used by jsan and [parsing fails](https://github.com/zalmoxisus/redux-devtools-extension/issues/278#issuecomment-271988979). The solution is to skip `undefined` part of the path. It shouldn't be a problem for other cases, as if we're not at the end of the path and got `undefined`, it will fail for sure.