### PR TITLE
Keep global Symbols

### DIFF
--- a/lib/cycle.js
+++ b/lib/cycle.js
@@ -59,6 +59,11 @@ exports.decycle = function decycle(object, options, replacer) {
       return {$jsan: 'e' + value.message}
     }
     if (options['symbol'] && typeof value === 'symbol') {
+      var symbolKey = Symbol.keyFor(value)
+      if (symbolKey !== undefined) {
+        return {$jsan: 'g' + symbolKey}
+      }
+
       // 'Symbol(foo)'.slice(7, -1) === 'foo'
       return {$jsan: 's' + value.toString().slice(7, -1)}
     }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -44,6 +44,8 @@ exports.restore = function restore(obj, root) {
       return error;
     case 's':
       return Symbol(rest);
+    case 'g':
+      return Symbol.for(rest);
     default:
       console.warn('unknown type', obj);
       return obj;

--- a/test/unit.js
+++ b/test/unit.js
@@ -66,6 +66,14 @@ describe('jsan', function() {
         var str = jsan.stringify(obj, null, null, true);
         assert.deepEqual(str, '{"s":{"$jsan":"sa"}}');
       });
+
+      it('can handle global ES symbols', function() {
+        var obj = {
+          g: Symbol.for('a')
+        }
+        var str = jsan.stringify(obj, null, null, true);
+        assert.deepEqual(str, '{"g":{"$jsan":"ga"}}');
+      });
     }
 
     it('works on objects with circular references', function() {
@@ -159,6 +167,13 @@ describe('jsan', function() {
         var obj = jsan.parse(str);
         assert(typeof obj.s1 === 'symbol' && obj.s1.toString() === 'Symbol(foo)');
         assert(typeof obj.s2 === 'symbol' && obj.s2.toString() === 'Symbol()');
+      });
+
+      it('can decode global ES symbols', function() {
+        str = '{"g1":{"$jsan":"gfoo"}, "g2":{"$jsan":"gundefined"}}';
+        var obj = jsan.parse(str);
+        assert(typeof obj.g1 === 'symbol' && obj.g1 === Symbol.for('foo'));
+        assert(typeof obj.g2 === 'symbol' && obj.g2 === Symbol.for());
       });
     }
 


### PR DESCRIPTION
Right now `Symbol`s obviously lose their identuty during `stringify/parse`, but at least global symbols (`Symbol.for`) can be safely retained.

This would allow for:

```js
var obj = { s: Symbol("sym"), g: Symbol.for("globalSym") };
var res = jsan.parse(jsan.stringify(obj, null, null, true));

assert(res.s !== obj.s)  // Symbol() are unique
assert(res.g === obj.g)  // same global Symbol
```