### PR TITLE
Prevent infinite recursions when using `refs`option as `false`

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -29,6 +29,14 @@ exports.stringify = function stringify(value, replacer, space, _options) {
   }
   if (typeof options.refs === 'undefined') options.refs = true;
 
+  if (!options.refs) {
+    try {
+      JSON.stringify(value);
+    } catch (e) {
+      options.refs = true;
+    }
+  }
+
   var decycled = cycle.decycle(value, options, replacer);
   if (arguments.length === 1) {
     return JSON.stringify(decycled);

--- a/test/unit.js
+++ b/test/unit.js
@@ -199,6 +199,15 @@ describe('jsan', function() {
       assert.equal(jsan.stringify(obj, null, null, {refs: false}), '{"prop1":{"a":1},"prop2":{"prop3":{"a":1}}}');
     });
 
+    it('ignores refs option if there are circular references', function() {
+      var obj = {};
+      obj.self = obj;
+      obj.a = 1;
+      obj.b = {};
+      obj.c = obj.b;
+      assert.equal(jsan.stringify(obj, null, null, {refs: false}), '{"self":{"$jsan":"$"},"a":1,"b":{},"c":{"$jsan":"$.b"}}');
+    });
+
     it('works on objects with "[", "\'", and "]" in the keys', function() {
       var obj = {};
       obj['["key"]'] = {};


### PR DESCRIPTION
When using new `refs`option as `false` introduced in https://github.com/kolodny/jsan/commit/802155333921c867aa8499f844975f39b1f11d76, jsan will not handle circular references (as there will be no references to check), so there will be an infinite recursion in those cases. A simple solution is to check if regular `JSON.stringify` fails and disable that option in that case. It is not the best solution as there could be other exceptions. We could check error message, but it's different in every browser. Another solution is to stringify it as usually then replace references, but that would be probably much slower.

I'll keep it open for suggestions and will ship a patch without handling it as `refs` is new option which won't break any current usage. And anyway it was infinite recursion in recent versions when using reviver.