### PR TITLE
Issue #30 -addresses false positive in cycle detection

### DIFF
--- a/lib/cycle.js
+++ b/lib/cycle.js
@@ -111,7 +111,14 @@ exports.decycle = function decycle(object, options, replacer) {
           if (noCircularOption && withRefs) {
             return {$jsan: foundPath};
           }
-          if (path.indexOf(foundPath) === 0) {
+          
+          // This is only a true circular reference if the parent path is inside of foundPath
+          // drop the last component of the current path and check if it starts with foundPath
+          var pathElements = path.split('.');
+          var parentPathElements = pathElements.slice(0, pathElements.length - 1)
+          var parentPathString = parentPathElements.join('.');
+
+          if (parentPathString.indexOf(foundPath) === 0) {
             if (!noCircularOption) {
               return typeof options.circular === 'function'?
               options.circular(value, path, foundPath):

--- a/lib/cycle.js
+++ b/lib/cycle.js
@@ -114,11 +114,8 @@ exports.decycle = function decycle(object, options, replacer) {
           
           // This is only a true circular reference if the parent path is inside of foundPath
           // drop the last component of the current path and check if it starts with foundPath
-          var pathElements = path.split('.');
-          var parentPathElements = pathElements.slice(0, pathElements.length - 1)
-          var parentPathString = parentPathElements.join('.');
-
-          if (parentPathString.indexOf(foundPath) === 0) {
+          var parentPath = path.split('.').slice(0, -1).join('.');
+          if (parentPath.indexOf(foundPath) === 0) {
             if (!noCircularOption) {
               return typeof options.circular === 'function'?
               options.circular(value, path, foundPath):

--- a/test/unit.js
+++ b/test/unit.js
@@ -238,6 +238,28 @@ describe('jsan', function() {
       assert.equal(jsan.stringify(obj), '{"self":{"$jsan":"$"},"a":{},"b":{"$jsan":"$.a"}}');
     });
 
+    it('does not report false positives for circular references', function() {
+      /**
+       * This is a test for an edge case in which jsan.stringify falsely reported circular references
+       * The minimal conditions are
+       * 1) The object has an error preventing serialization by json.stringify
+       * 2) The object contains a repeated reference
+       * 3) the second path of the reference contains the first path
+       */
+      var circular = {};
+      circular.self = circular;
+      
+      var ref = {};
+      
+      var obj = {
+        circularRef: circular,
+        ref: ref,
+        refAgain: ref,
+      };
+      
+      var result = jsan.stringify(obj, null, null, { circular: "[CIRCULAR]" });
+      assert.equal('{"circularRef":{"self":"[CIRCULAR]"},"ref":{},"refAgain":{"$jsan":"$.ref"}}', result)
+    });
   });
 
 


### PR DESCRIPTION
This updates the path comparison used in cycle detection to ignore the final component of the path for references which have been seen before. This fixes an edge case where false positives were reported.

There's a unit test for `jsan.stringify` verifying the change, which fails when it is reverted. Existing tests pass.